### PR TITLE
Improving error handling on API calls

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -168,6 +168,16 @@ class Client
             ]
         ], $customArgs ));
         $data = \GuzzleHttp\json_decode($res->getBody());
+        if (isset($data->isError) && $data->isError) {
+            throw new \Exception("Sbanken API returned error"
+                . " (response code " . $res->getStatusCode() . " " . $res->getReasonPhrase() . ")."
+                . " Please see attached JSON and headers.\n\n"
+                . "JSON RESPONSE:\n"
+                . json_encode($data, JSON_PRETTY_PRINT) . "\n\n"
+                . "HEADERS:\n"
+                . json_encode($res->getHeaders(), JSON_PRETTY_PRINT)
+            );
+        }
         return $data;
     }
 


### PR DESCRIPTION
Sbanken is returning isError = true when you do something you are not
allowed to. E.g. wrong national ID number.

Example exception message:

	Sbanken API returned error (response code 200 OK). Please see attached JSON and headers.

	JSON RESPONSE:
	{
	    "errorType": 1,
	    "isError": true,
	    "errorMessage": "Merchant is not authorized to request the customerId which was requested",
	    "traceId": "68eb6072-2a8c-49c2-89b8-f2d0ee0a1dfe"
	}

	HEADERS:
	{
	    "Transfer-Encoding": [
		"chunked"
	    ],
	    "Content-Type": [
		"application\/json; charset=utf-8"
	    ],
	    "X-Rate-Limit-Limit": [
		"1d"
	    ],
	    "X-Rate-Limit-Remaining": [
		"249963"
	    ],
	    "X-Rate-Limit-Reset": [
		"2018-02-02T22:08:47.4000000Z"
	    ],
	    "Strict-Transport-Security": [
		"max-age=31536000; includeSubDomains; preload"
	    ],
	    "Date": [
		"Thu, 01 Feb 2018 22:20:30 GMT"
	    ]
	}