### PR TITLE
Support for Sbanken Transaction API v2.

### DIFF
--- a/examples/transactionsV2.php
+++ b/examples/transactionsV2.php
@@ -1,0 +1,30 @@
+<?php
+require '../vendor/autoload.php';
+
+// WARNING!
+// PLEASE BE VERY CAREFUL WITH CLIENT_ID, SECRET AND CUSTOMER_ID
+// NEVER STORE THESE IN SCRIPTS. USE BEST PRACTICES AND USE ENVIRONMENT VARIABLES.
+$credentials = new \Pkj\Sbanken\Credentials(
+    getenv('CLIENT_ID'),
+    getenv('CLIENT_SECRET'),
+    getenv('CUSTOMER_ID')
+);
+$accountNumber = getenv('ACCOUNT_NUMBER');
+
+$client = \Pkj\Sbanken\Client::factory($credentials);
+
+$client->authorize();
+
+$transactionRequest = new \Pkj\Sbanken\Request\TransactionV2ListRequest($accountNumber);
+$transactionRequest->setIndex(0); // For pagination use getAvailableItems below and this one.
+$transactionRequest->setStartDate(new \DateTime('-1 year')); // Just get transactions for the past year. ( max -366 days in sbanken..).
+
+$transactions = $client->TransactionsV2()->getList($transactionRequest);
+
+echo "There are total of {$transactions->getAvailableItems()} transactions!\n\n";
+
+foreach ($transactions as $transaction){
+    echo "{$transaction->accountingDate->format('d.m-Y')}: {$transaction->amount} NOK\n";
+}
+
+

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ namespace Pkj\Sbanken;
 use GuzzleHttp\ClientInterface;
 use Pkj\Sbanken\Endpoint\Accounts;
 use Pkj\Sbanken\Endpoint\Transactions;
+use Pkj\Sbanken\Endpoint\TransactionsV2;
 use Pkj\Sbanken\Endpoint\Transfers;
 use Pkj\Sbanken\Exceptions\SbankenItemNotFoundException;
 use Pkj\Sbanken\Values\SbankenApiCredentials;
@@ -75,6 +76,16 @@ class Client
     public function Transactions ()
     {
         return new Transactions($this);
+    }
+
+    /**
+     * Use to deal with transactions in API version 2.
+     *
+     * @return TransactionsV2
+     */
+    public function TransactionsV2 ()
+    {
+        return new TransactionsV2($this);
     }
 
     /**

--- a/src/Endpoint/TransactionsV2.php
+++ b/src/Endpoint/TransactionsV2.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Pkj\Sbanken\Endpoint;
+
+use Pkj\Sbanken\Request\TransactionV2ListRequest;
+use Pkj\Sbanken\Values\TransactionV2;
+
+class TransactionsV2
+{
+    use HasClient;
+
+    const ENDPOINT_LIST = '/bank/api/v2/Transactions/{customerId}/{accountNumber}';
+
+    /**
+     * @return \Pkj\Sbanken\Values\TransactionV2[]|\Pkj\Sbanken\Values\Collection
+     */
+    public function getList (TransactionV2ListRequest $request) {
+        $customArgs = [
+            'query' => $request ? $request->toRequestArray() : null
+        ];
+        $endpoint = str_replace('{accountNumber}', $request->getAccountNumber(), self::ENDPOINT_LIST);
+        return $this->client->queryEndpointList('GET', $endpoint, TransactionV2::class, $customArgs);
+    }
+}

--- a/src/Request/TransactionV2ListRequest.php
+++ b/src/Request/TransactionV2ListRequest.php
@@ -1,0 +1,129 @@
+<?php
+namespace Pkj\Sbanken\Request;
+
+/**
+ * Corresponds to https://api.sbanken.no/Bank/swagger/#!/GET/ApiV2TransactionsByCustomerIdByAccountNumberGet
+ */
+class TransactionV2ListRequest
+{
+    /**
+     * @var int|null
+     */
+    private $index;
+
+    /**
+     * @var int|null
+     */
+    private $length;
+
+    /**
+     * @var \DateTime|null
+     */
+    private $startDate;
+
+    /**
+     * @var \DateTime|null
+     */
+    private $endDate;
+
+    /**
+     * @var string
+     */
+    private $accountNumber;
+
+    public function __construct(string $accountNumber)
+    {
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * @return int
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * @param int $index
+     */
+    public function setIndex(int $index)
+    {
+        $this->index = $index;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLength()
+    {
+        return $this->length;
+    }
+
+    /**
+     * @param int $length
+     */
+    public function setLength(int $length)
+    {
+        $this->length = $length;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    /**
+     * @param \DateTime $startDate
+     */
+    public function setStartDate(\DateTime $startDate)
+    {
+        $this->startDate = $startDate;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * @param \DateTime $endDate
+     */
+    public function setEndDate(\DateTime $endDate)
+    {
+        $this->endDate = $endDate;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountNumber()
+    {
+        return $this->accountNumber;
+    }
+
+
+    public function toRequestArray () {
+        $requestData = [];
+        if ($this->getIndex()) {
+            $requestData['index'] = $this->getIndex();
+        }
+        if ($this->getLength()) {
+            $requestData['length'] = $this->getLength();
+        }
+        if ($this->getStartDate()) {
+            $requestData['startDate'] = $this->getStartDate()->format(DATE_RFC3339);
+        }
+        if ($this->getEndDate()) {
+            $requestData['endDate'] = $this->getEndDate()->format(DATE_RFC3339);
+        }
+        return $requestData;
+    }
+
+}

--- a/src/Values/TransactionV2.php
+++ b/src/Values/TransactionV2.php
@@ -1,0 +1,73 @@
+<?php
+namespace Pkj\Sbanken\Values;
+
+/**
+ * See API documentation for details: https://api.sbanken.no/Bank/swagger/#!/GET/ApiV2TransactionsByCustomerIdByAccountNumberGet
+ *
+ * @property-read string $transactionId
+ * @property-read \DateTime $accountingDate
+ * @property-read \DateTime $interestDate
+ * @property-read string $otherAccountNumber
+ * @property-read bool $otherAccountNumberSpecified
+ * @property-read float $amount
+ * @property-read string $text
+ * @property-read string $transactionType
+ * @property-read float $transactionTypeCode
+ * @property-read string $transactionTypeText
+ * @property-read bool $isReservation
+ * @property-read string/enum $reservationType Enum containing ['notReservation', 'visaReservation', 'purchaseReservation', 'atmReservation']
+ * @property-read string/enum $source Enum containing ['accountStatement', 'archive']
+ * @property-read TransactionV2CardDetails $cardDetails Optionally contains details about the transaction. See cardDetailsSpecified
+ * @property-read bool $cardDetailsSpecified
+ *
+ * @package Pkj\Sbanken\Values
+ */
+class TransactionV2 extends ValueObject
+{
+    public function __construct(array $properties = array())
+    {
+        if ($properties['accountingDate'] !== null) {
+            $properties['accountingDate'] = new \DateTime($properties['accountingDate']);
+        }
+        if ($properties['interestDate'] !== null) {
+            $properties['interestDate'] = new \DateTime($properties['interestDate']);
+        }
+
+        if ($properties['cardDetailsSpecified']) {
+            $properties['cardDetails'] = new TransactionV2CardDetails((array) $properties['cardDetails']);
+        }
+
+        parent::__construct($properties);
+    }
+
+    // Note: not described in API documentation. Bug filed: https://github.com/Sbanken/api-examples/issues/13
+    protected $transactionId;
+
+    protected $accountingDate;
+
+    protected $interestDate;
+
+    protected $otherAccountNumber;
+
+    protected $otherAccountNumberSpecified;
+
+    protected $amount;
+
+    protected $text;
+
+    protected $transactionType;
+
+    protected $transactionTypeCode;
+
+    protected $transactionTypeText;
+
+    protected $isReservation;
+
+    protected $reservationType;
+
+    protected $source;
+
+    protected $cardDetails;
+
+    protected $cardDetailsSpecified;
+}

--- a/src/Values/TransactionV2CardDetails.php
+++ b/src/Values/TransactionV2CardDetails.php
@@ -1,0 +1,50 @@
+<?php
+namespace Pkj\Sbanken\Values;
+
+/**
+ * See API documentation for details: https://api.sbanken.no/Bank/swagger/#!/GET/ApiV2TransactionsByCustomerIdByAccountNumberGet
+ *
+ * @property-read string cardNumber
+ * @property-read float currencyAmount
+ * @property-read float currencyRate
+ * @property-read string merchantCategoryCode
+ * @property-read string merchantCategoryDescription
+ * @property-read string merchantCity
+ * @property-read string merchantName
+ * @property-read string originalCurrencyCode
+ * @property-read \DateTime purchaseDate
+ * @property-read string transactionId
+ *
+ * @package Pkj\Sbanken\Values
+ */
+class TransactionV2CardDetails extends ValueObject
+{
+    public function __construct(array $properties = array())
+    {
+        if ($properties['purchaseDate'] !== null) {
+            $properties['purchaseDate'] = new \DateTime($properties['purchaseDate']);
+        }
+
+        parent::__construct($properties);
+    }
+
+    protected $cardNumber;
+
+    protected $currencyAmount;
+
+    protected $currencyRate;
+
+    protected $merchantCategoryCode;
+
+    protected $merchantCategoryDescription;
+
+    protected $merchantCity;
+
+    protected $merchantName;
+
+    protected $originalCurrencyCode;
+
+    protected $purchaseDate;
+
+    protected $transactionId;
+}


### PR DESCRIPTION
Mainly based on API documentation found at
https://api.sbanken.no/Bank/swagger/#!/GET/ApiV2TransactionsByCustomerIdByAccountNumberGet

Field two bugs during this process:

- Swagger - Transactions v2 is missing "transactionId" in API doc
  https://github.com/Sbanken/api-examples/issues/13

- API does not contain string enum values for source
  https://github.com/Sbanken/api-examples/issues/14

The field "otherAccountNumber" might not be present:
- "The otherAccountNumber is still missing in V2. Does the v2
   otherAccountNumber field only apply to new transactions?"
   + examples
  https://github.com/Sbanken/api-examples/issues/9#issuecomment-370013887